### PR TITLE
added bluesky and facebook to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,9 @@ Supported Silos
 Right now, the following silos are supported:
 
 - `Mastodon`_: an open, federated social network and microblogging service.
+- `Bluesky`_: an open, federated social network and microblogging service.
 - `Twitter`_: a proprietary social network and microblogging service.
+- `Facebook`_: a proprietary social network and microblogging service.
 - Print: a debug silo that just prints entries in the console.
 
 


### PR DESCRIPTION
Just added bluesky and facebook to readme after seeing files for them in the `silos` directory. I'm assuming these are functional right? Looking forward to getting this setup with all working silos.

Thank you for creating this!